### PR TITLE
Added 'Encoding' option

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,38 @@
 			<input id="prefdisablesounds" type="checkbox" class="prefinput">
 			<label class="preflabel" for="prefautoplayvideos">Autoplay log videos:</label>
 			<input id="prefautoplayvideos" type="checkbox" class="prefinput">
+			<label class="preflabel" for="prefencoding">Encoding:</label>
+			<select id="prefencoding" class="prefinput">
+				<optgroup>
+					<option value="windows-1252">Western (Windows-1252)</option>
+					<option value="macintosh">Western (Macintosh)</option>
+					<option value="iso-8859-15">Western (ISO-8859-15)</option>
+					<option value="iso-8859-1">Western (ISO-8859-1)</option>
+				</optgroup>
+				<optgroup>
+					<option value="utf-8">Unicode (UTF-8)</option>
+					<option value="utf-16">Unicode (UTF-16)</option>
+				</optgroup>
+				<optgroup>
+					<option value="shift_jis">Japanese (Shift_JIS)</option>
+				</optgroup>
+				<optgroup>
+					<option value="gb2312">Chinese Simplified (GB2312)</option>
+					<option value="gbk">Chinese Simplified (GBK)</option>
+					<option value="big5">Chinese Traditional (Big5)</option>
+				</optgroup>
+				<optgroup>
+					<option value="iso-8859-5">Cyrillic (ISO-8859-5)</option>
+					<option value="windows-1251">Cyrillic (Windows-1251)</option>
+				</optgroup>
+				<optgroup>
+					<option value="iso-8859-14">Celtic (ISO-8859-14)</option>
+				</optgroup>
+				<optgroup>
+					<option value="windows-1253">Greek (Widows-1253)</option>
+					<option value="iso-8859-7">Greek (ISO-8859-7)</option>
+				</optgroup>
+			</select>
 		</div>
 
 		<div id="authenticate" class="zoompanel" data-state=0>

--- a/js/client.js
+++ b/js/client.js
@@ -197,8 +197,7 @@ class PalaceProtocol {
 
 	connect(ip,port) {
 
-		this.textDecoder = new TextDecoder('windows-1252'); // default server encoding
-		this.textEncoder = new TextEncoder('windows-1252', { NONSTANDARD_allowLegacyEncoding: true }); // palace default! :\
+		this.setEncoder(prefs.general.encoding);
 
 		if (!port) port = '9998';
 		this.ip = ip.trim();
@@ -1160,6 +1159,10 @@ class PalaceProtocol {
 		this.send(packet);
 	}
 
+	setEncoder(encoding) {
+		this.textDecoder = new TextDecoder(encoding);
+		this.textEncoder = new TextEncoder(encoding, { NONSTANDARD_allowLegacyEncoding: true }); // palace default! :\
+	}
 }
 
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -385,6 +385,15 @@ if (window.require) {
 	document.getElementById('prefhomepalace').onchange = function() {
 		setGeneralPref('home',this.value);
 	};
+	document.getElementById('prefencoding').onchange = function() {
+		try {
+			palace.setEncoder(this.value);
+			setGeneralPref('encoding',this.value);
+		} catch (error) {
+			logerror(error);
+			this.value = getGeneralPref('encoding');
+		}
+	};
 	document.getElementById('prefpropbagsize').oninput = function() { // change prop bag tile size :D
 		setGeneralPref('propBagTileSize',this.value);
 		refreshPropBagView(true);

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -20,8 +20,8 @@ function setGeneralPref(id,value) {
 	prefs.general[id] = value;
 }
 
-function getGeneralPref(id) {
-	return prefs.general[id];
+function getGeneralPref(id,def) {
+	return prefs.general.hasOwnProperty(id) ? prefs.general[id] : def;
 }
 
 window.onunload = function(e) {
@@ -66,4 +66,5 @@ window.onunload = function(e) {
 	}
 	document.getElementById('prefusername').value = getGeneralPref('userName');
 	document.getElementById('prefhomepalace').value = getGeneralPref('home');
+	document.getElementById('prefencoding').value = getGeneralPref('encoding','windows-1252');
 })();


### PR DESCRIPTION
Hi @pawnipt ,

Thanks a lot for your continued work on Palace!
Now that the old PalaceChat stops working on Catalina, I plan to use this client with a few modifications crucial to my usage.

So, here is my first PR which ports the old 'Character Encoding' setting from PalaceChat.
'Celtic (MacCeltic)' is removed as it seems to be unsupported in TextEncoder/Decoder.

If you are not interested, please feel free to close this (or any of my future PRs).
I don't mind maintaining my modifications on my fork. :)

<img width="400" src="https://user-images.githubusercontent.com/149268/66741708-14607a80-eeb1-11e9-8d7a-27cd390afbd5.png">