### PR TITLE
Load legacy props if http media request failed

### DIFF
--- a/js/props.js
+++ b/js/props.js
@@ -541,8 +541,13 @@ function loadProps(pids,fromSelf,callback) {
                         }
                     }
                 },
-                function(status) { // handle error, maybe retry upload
-                    logmsg('Prop download failed (HTTP ERROR): '+status);
+                function(status) {
+					toLoad.props.map(p => cacheProps[p.id]).filter(p => p).forEach(aProp => {
+						if (aProp.rcounter === 0) { // only request legacy prop once.
+							palace.sendAssetQuery(aProp.id);
+						}
+						aProp.rcounter++;
+					});
                 }
             );
         }


### PR DESCRIPTION
I removed the `logmsg` call as it outputs the same message every time someone wears a new prop on our server.
If you prefer to keep the log output, please let me know and I'll think of something (e.g. printing the message just once).
